### PR TITLE
Keeping the decimal place for media queries

### DIFF
--- a/test/fixtures/small.css
+++ b/test/fixtures/small.css
@@ -1,7 +1,7 @@
 .red { color: red !important }
 
-@media (min-width: 30em) {
-  .sm-tomato { color: tomato; background-color: hotpink; }
+@media (min-width: 30.123em) {
+  .sm-tomato { color: tomato; background-color: hotpink; width: 55.625em; }
 }
 
 @keyframes grow {

--- a/test/results/small.json
+++ b/test/results/small.json
@@ -1,10 +1,10 @@
 {
   "averages": {
     "specificity": 5.5,
-    "ruleSize": 2.75
+    "ruleSize": 3
   },
-  "size": 552,
-  "gzipSize": 216,
+  "size": 573,
+  "gzipSize": 232,
   "selectors": [
     {
       "selector": ".red",
@@ -96,6 +96,12 @@
           "prop": "background-color",
           "value": "hotpink",
           "index": 2
+        },
+        {
+          "type": "decl",
+          "prop": "width",
+          "value": "55.625em",
+          "index": 3
         }
       ],
       "declarations": [
@@ -110,6 +116,12 @@
           "prop": "background-color",
           "value": "hotpink",
           "index": 2
+        },
+        {
+          "type": "decl",
+          "prop": "width",
+          "value": "55.625em",
+          "index": 3
         }
       ],
       "selector": ".sm-tomato"
@@ -121,26 +133,26 @@
           "type": "decl",
           "prop": "opacity",
           "value": "0",
-          "index": 3
+          "index": 4
         },
         {
           "type": "decl",
           "prop": "-webkit-transform",
           "value": "translateY(-20px) translate3d(0, 0, 0)",
-          "index": 4
+          "index": 5
         },
         {
           "type": "decl",
           "prop": "-ms-transform",
           "value": "translateY(-20px) translate3d(0, 0, 0)",
-          "index": 5
+          "index": 6
         },
         {
           "type": "decl",
           "prop": "transform",
           "important": true,
           "value": "translateY(-20px) translate3d(0, 0, 0)",
-          "index": 6
+          "index": 7
         }
       ],
       "declarations": [
@@ -148,26 +160,26 @@
           "type": "decl",
           "prop": "opacity",
           "value": "0",
-          "index": 3
+          "index": 4
         },
         {
           "type": "decl",
           "prop": "-webkit-transform",
           "value": "translateY(-20px) translate3d(0, 0, 0)",
-          "index": 4
+          "index": 5
         },
         {
           "type": "decl",
           "prop": "-ms-transform",
           "value": "translateY(-20px) translate3d(0, 0, 0)",
-          "index": 5
+          "index": 6
         },
         {
           "type": "decl",
           "prop": "transform",
           "important": true,
           "value": "translateY(-20px) translate3d(0, 0, 0)",
-          "index": 6
+          "index": 7
         }
       ],
       "selector": "0%"
@@ -179,25 +191,25 @@
           "type": "decl",
           "prop": "opacity",
           "value": "1",
-          "index": 7
+          "index": 8
         },
         {
           "type": "decl",
           "prop": "-webkit-transform",
           "value": "translateY(0) translate3d(0, 0, 0)",
-          "index": 8
+          "index": 9
         },
         {
           "type": "decl",
           "prop": "-ms-transform",
           "value": "translateY(0) translate3d(0, 0, 0)",
-          "index": 9
+          "index": 10
         },
         {
           "type": "decl",
           "prop": "transform",
           "value": "translateY(0) translate3d(0, 0, 0)",
-          "index": 10
+          "index": 11
         }
       ],
       "declarations": [
@@ -205,25 +217,25 @@
           "type": "decl",
           "prop": "opacity",
           "value": "1",
-          "index": 7
+          "index": 8
         },
         {
           "type": "decl",
           "prop": "-webkit-transform",
           "value": "translateY(0) translate3d(0, 0, 0)",
-          "index": 8
+          "index": 9
         },
         {
           "type": "decl",
           "prop": "-ms-transform",
           "value": "translateY(0) translate3d(0, 0, 0)",
-          "index": 9
+          "index": 10
         },
         {
           "type": "decl",
           "prop": "transform",
           "value": "translateY(0) translate3d(0, 0, 0)",
-          "index": 10
+          "index": 11
         }
       ],
       "selector": "100%"
@@ -252,52 +264,58 @@
       },
       {
         "type": "decl",
+        "prop": "width",
+        "value": "55.625em",
+        "index": 3
+      },
+      {
+        "type": "decl",
         "prop": "opacity",
         "value": "0",
-        "index": 3
+        "index": 4
       },
       {
         "type": "decl",
         "prop": "-webkit-transform",
         "value": "translateY(-20px) translate3d(0, 0, 0)",
-        "index": 4
+        "index": 5
       },
       {
         "type": "decl",
         "prop": "-ms-transform",
         "value": "translateY(-20px) translate3d(0, 0, 0)",
-        "index": 5
+        "index": 6
       },
       {
         "type": "decl",
         "prop": "transform",
         "important": true,
         "value": "translateY(-20px) translate3d(0, 0, 0)",
-        "index": 6
+        "index": 7
       },
       {
         "type": "decl",
         "prop": "opacity",
         "value": "1",
-        "index": 7
+        "index": 8
       },
       {
         "type": "decl",
         "prop": "-webkit-transform",
         "value": "translateY(0) translate3d(0, 0, 0)",
-        "index": 8
+        "index": 9
       },
       {
         "type": "decl",
         "prop": "-ms-transform",
         "value": "translateY(0) translate3d(0, 0, 0)",
-        "index": 9
+        "index": 10
       },
       {
         "type": "decl",
         "prop": "transform",
         "value": "translateY(0) translate3d(0, 0, 0)",
-        "index": 10
+        "index": 11
       }
     ],
     "byProperty": {
@@ -324,18 +342,26 @@
           "index": 2
         }
       ],
+      "width": [
+        {
+          "type": "decl",
+          "prop": "width",
+          "value": "55.625em",
+          "index": 3
+        }
+      ],
       "opacity": [
         {
           "type": "decl",
           "prop": "opacity",
           "value": "0",
-          "index": 3
+          "index": 4
         },
         {
           "type": "decl",
           "prop": "opacity",
           "value": "1",
-          "index": 7
+          "index": 8
         }
       ],
       "webkitTransform": [
@@ -343,13 +369,13 @@
           "type": "decl",
           "prop": "-webkit-transform",
           "value": "translateY(-20px) translate3d(0, 0, 0)",
-          "index": 4
+          "index": 5
         },
         {
           "type": "decl",
           "prop": "-webkit-transform",
           "value": "translateY(0) translate3d(0, 0, 0)",
-          "index": 8
+          "index": 9
         }
       ],
       "msTransform": [
@@ -357,13 +383,13 @@
           "type": "decl",
           "prop": "-ms-transform",
           "value": "translateY(-20px) translate3d(0, 0, 0)",
-          "index": 5
+          "index": 6
         },
         {
           "type": "decl",
           "prop": "-ms-transform",
           "value": "translateY(0) translate3d(0, 0, 0)",
-          "index": 9
+          "index": 10
         }
       ],
       "transform": [
@@ -372,13 +398,13 @@
           "prop": "transform",
           "important": true,
           "value": "translateY(-20px) translate3d(0, 0, 0)",
-          "index": 6
+          "index": 7
         },
         {
           "type": "decl",
           "prop": "transform",
           "value": "translateY(0) translate3d(0, 0, 0)",
-          "index": 10
+          "index": 11
         }
       ]
     },
@@ -406,18 +432,26 @@
           "index": 2
         }
       ],
+      "width": [
+        {
+          "type": "decl",
+          "prop": "width",
+          "value": "55.625em",
+          "index": 3
+        }
+      ],
       "opacity": [
         {
           "type": "decl",
           "prop": "opacity",
           "value": "0",
-          "index": 3
+          "index": 4
         },
         {
           "type": "decl",
           "prop": "opacity",
           "value": "1",
-          "index": 7
+          "index": 8
         }
       ],
       "webkitTransform": [
@@ -425,13 +459,13 @@
           "type": "decl",
           "prop": "-webkit-transform",
           "value": "translateY(-20px) translate3d(0, 0, 0)",
-          "index": 4
+          "index": 5
         },
         {
           "type": "decl",
           "prop": "-webkit-transform",
           "value": "translateY(0) translate3d(0, 0, 0)",
-          "index": 8
+          "index": 9
         }
       ],
       "msTransform": [
@@ -439,13 +473,13 @@
           "type": "decl",
           "prop": "-ms-transform",
           "value": "translateY(-20px) translate3d(0, 0, 0)",
-          "index": 5
+          "index": 6
         },
         {
           "type": "decl",
           "prop": "-ms-transform",
           "value": "translateY(0) translate3d(0, 0, 0)",
-          "index": 9
+          "index": 10
         }
       ],
       "transform": [
@@ -454,18 +488,18 @@
           "prop": "transform",
           "important": true,
           "value": "translateY(-20px) translate3d(0, 0, 0)",
-          "index": 6
+          "index": 7
         },
         {
           "type": "decl",
           "prop": "transform",
           "value": "translateY(0) translate3d(0, 0, 0)",
-          "index": 10
+          "index": 11
         }
       ]
     },
     "byMedia": {
-      "(minWidth:30em)": [
+      "(minWidth:30123em)": [
         {
           "type": "decl",
           "prop": "color",
@@ -477,6 +511,12 @@
           "prop": "background-color",
           "value": "hotpink",
           "index": 2
+        },
+        {
+          "type": "decl",
+          "prop": "width",
+          "value": "55.625em",
+          "index": 3
         }
       ]
     },
@@ -485,23 +525,28 @@
   },
   "aggregates": {
     "selectors": 4,
-    "declarations": 11,
+    "declarations": 12,
     "properties": [
       "color",
       "backgroundColor",
+      "width",
       "opacity",
       "webkitTransform",
       "msTransform",
       "transform"
     ],
     "mediaQueries": [
-      "(minWidth:30em)"
+      "(minWidth:30123em)"
     ],
     "color": {
       "total": 2,
       "unique": 2
     },
     "backgroundColor": {
+      "total": 1,
+      "unique": 1
+    },
+    "width": {
       "total": 1,
       "unique": 1
     },

--- a/test/test.js
+++ b/test/test.js
@@ -7,16 +7,17 @@ describe('css-statistics', function() {
 
   before(function() {
     stats = cssstats(fixture('small'));
+    console.log(stats);
   });
 
   describe('base stats', function() {
 
     it('should calculate the correct file size', function() {
-      assert.equal(stats.size, 552);
+      assert.equal(stats.size, 573);
     });
 
     it('should calculate the correct gzipped file size', function() {
-      assert.equal(stats.gzipSize, 216);
+      assert.equal(stats.gzipSize, 232);
     });
   });
 
@@ -27,29 +28,41 @@ describe('css-statistics', function() {
     });
 
     it('should correctly count rule size stats', function() {
-      assert.equal(stats.averages.ruleSize, 2.75);
+      assert.equal(stats.averages.ruleSize, 3);
     });
   });
 
   describe('aggregates', function() {
 
     it('should correclty count declarations', function() {
-      assert.equal(stats.aggregates.declarations, 11);
+      assert.equal(stats.aggregates.declarations, 12);
     });
 
-    it('should correclty count selectors', function() {
+    it('should correctly count selectors', function() {
       assert.equal(stats.aggregates.selectors, 4);
+    });
+
+    it('should correctly count media queries', function() {
+      assert.equal(stats.aggregates.mediaQueries.length, 1);
+    });
+
+    it('should maintain the units from the media query', function() {
+      assert.equal(stats.aggregates.mediaQueries[0], '(minWidth:30.123em)');
     });
   });
 
   describe('declarations', function() {
 
-    it('should correclty count vendor prefixes', function() {
+    it('should correctly count vendor prefixes', function() {
       assert.equal(stats.declarations.vendorPrefixCount, 4);
     });
 
-    it('should correclty count important values', function() {
+    it('should correctly count important values', function() {
       assert.equal(stats.declarations.importantCount, 2);
+    });
+
+    it('should correctly maintains em units', function() {
+      assert.equal(stats.declarations.unique.width[0].value, '55.625em');
     });
   });
 


### PR DESCRIPTION
Related to mrmrs/cssstats#76 and cssstats/cssstats#102
Related to #2 

I've added unit tests for media query parsing to replicate the issue referenced
above. Then, when attempting to get the test to pass I dove into how the
media queries were being handled. The current implementation doesn't hold
reference to the raw value after camel casing the key, so I don't believe
it's possible to fix this issue without changing the returned object.

So, I figured we could use this as the starting point to discuss the best
way to approach this. The first idea of mine is to slightly change the byMedia
key in the declarations object to be:

```javascript
byMedia: {
  '(minWidth:12345em)': {
    raw: '(min-width:12.345em)',
    declarations: [
      // ...
    ]
  }
}
```