### PR TITLE
Upgrade postcss

### DIFF
--- a/lib/rules.js
+++ b/lib/rules.js
@@ -11,9 +11,9 @@ module.exports = function(obj) {
 
   obj.eachRule(function(rule) {
     var declarations = [];
-    rule.childs.forEach(function(child) {
-      if (child.type == 'decl') {
-        declarations.push(child);
+    rule.nodes.forEach(function(node) {
+      if (node.type == 'decl') {
+        declarations.push(node);
       }
     });
 
@@ -22,7 +22,7 @@ module.exports = function(obj) {
 
     result.rules.push({
       type: rule.type,
-      childs: rule.childs,
+      childs: rule.nodes,
       declarations: declarations,
       selector: rule.selector
     });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cssstats",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "High-level stats for stylesheets",
   "main": "index.js",
   "author": "Brent Jackson",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "has-pseudo-element": "0.0.1",
     "is-vendor-prefixed": "0.0.1",
     "lodash": "^3.0.0",
-    "postcss": "^3.0.7",
+    "postcss": "^4.0.6",
     "specificity": "^0.1.4"
   },
   "repository": {


### PR DESCRIPTION
Turns out that the errors arose from postcss parsing, with an update
and a change (Container#childs was renamed to nodes) to lib/rules, everything
is in working order.

Closes #25 