### PR TITLE
Count property resets

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ __`declarations`:__ An object of declarations.
 - `declarations.byProperty`: An object with keys for each property found in the stylesheet.
 - `declarations.unique`: An object with keys for each unique property/value found in the stylesheet.
 - `declarations.byMedia`: An object with keys for each media query found in the stylesheet.
+- `declarations.propertyResetDeclarations`: An object with keys for each property with a value of `0` found in the stylesheet. (Actually only margins and paddings are counted)
 - `declarations.importantCount`: The number of declarations with values that contain `!important`
 - `declarations.vendorPrefixCount`: The number of declaration properties that have vendor prefixes.
 - `declarations.displayNoneCount`: The number of `display: none;` declarations.

--- a/lib/declarations.js
+++ b/lib/declarations.js
@@ -3,7 +3,7 @@ var camelCase = require('camelcase');
 var isVendorPrefixed = require('is-vendor-prefixed');
 
 var fontShorthand = require('./util/font-shorthand');
-var uniqueDeclarations = require('./util/unique-declarations')
+var uniqueDeclarations = require('./util/unique-declarations');
 
 module.exports = function(obj) {
   var uniqueDeclarationsCache = {};
@@ -14,6 +14,7 @@ module.exports = function(obj) {
     byProperty: {},
     unique: {},
     byMedia: {},
+    propertyResetDeclarations: {},
     importantCount: 0,
     vendorPrefixCount: 0,
     displayNoneCount: 0,
@@ -37,6 +38,14 @@ module.exports = function(obj) {
 
         if (declaration.prop === 'display' && declaration.value === 'none') {
           result.displayNoneCount++;
+        }
+
+        var relevant = ['margin', 'padding'].reduce(function (prop) {
+          return propKey.indexOf(prop) >= 0;
+        });
+        if (relevant && declaration.value.match(/^(?:0(?:px)? ?)+$/)) {
+          result.propertyResetDeclarations[propKey] |= 0;
+          result.propertyResetDeclarations[propKey]++;
         }
 
         delete declaration.source;

--- a/lib/declarations.js
+++ b/lib/declarations.js
@@ -43,7 +43,7 @@ module.exports = function(obj) {
         var relevant = ['margin', 'padding'].reduce(function (prop) {
           return propKey.indexOf(prop) >= 0;
         });
-        if (relevant && declaration.value.match(/^(?:0(?:px)? ?)+$/)) {
+        if (relevant && declaration.value.match(/^(?:0(?:\w{2,4}|%)? ?)+$/)) {
           result.propertyResetDeclarations[propKey] |= 0;
           result.propertyResetDeclarations[propKey]++;
         }

--- a/test/fixtures/small.css
+++ b/test/fixtures/small.css
@@ -10,6 +10,10 @@
 
 .sm-tomato:first-child:last-child { opacity: .8; border-bottom: none; }
 
+.box { margin: 10px; padding: 5px; }
+.box:first-child { margin: 0px 0; }
+.box:last-child { margin-bottom: 0px; }
+
 @keyframes grow {
   0% {
     opacity: 0;

--- a/test/results/basscss.json
+++ b/test/results/basscss.json
@@ -20859,6 +20859,13 @@
         }
       ]
     },
+    "propertyResetDeclarations": {
+      "margin": 3,
+      "marginTop": 6,
+      "marginLeft": 5,
+      "marginRight": 2,
+      "marginBottom": 1
+    },
     "importantCount": 10,
     "vendorPrefixCount": 28,
     "displayNoneCount": 6,

--- a/test/results/font-awesome.json
+++ b/test/results/font-awesome.json
@@ -31821,6 +31821,7 @@
       ]
     },
     "byMedia": {},
+    "propertyResetDeclarations": {},
     "importantCount": 0,
     "vendorPrefixCount": 17,
     "displayNoneCount": 0,

--- a/test/results/gridio-national-light.json
+++ b/test/results/gridio-national-light.json
@@ -12,6 +12,7 @@
     "byProperty": {},
     "unique": {},
     "byMedia": {},
+    "propertyResetDeclarations": {},
     "importantCount": 0,
     "vendorPrefixCount": 0,
     "displayNoneCount": 0,

--- a/test/results/gridio.json
+++ b/test/results/gridio.json
@@ -2707,6 +2707,7 @@
       ]
     },
     "byMedia": {},
+    "propertyResetDeclarations": {},
     "importantCount": 0,
     "vendorPrefixCount": 22,
     "displayNoneCount": 0,

--- a/test/results/small.json
+++ b/test/results/small.json
@@ -1,10 +1,10 @@
 {
   "averages": {
-    "specificity": 21.625,
-    "ruleSize": 2.2857142857142856
+    "specificity": 20.272727272727273,
+    "ruleSize": 2
   },
-  "size": 713,
-  "gzipSize": 293,
+  "size": 827,
+  "gzipSize": 336,
   "selectors": [
     {
       "selector": ".red",
@@ -101,6 +101,57 @@
         }
       ],
       "specificity_10": 30
+    },
+    {
+      "selector": ".box",
+      "specificity": "0,0,1,0",
+      "parts": [
+        {
+          "selector": ".box",
+          "type": "b",
+          "index": 0,
+          "length": 4
+        }
+      ],
+      "specificity_10": 10
+    },
+    {
+      "selector": ".box:first-child",
+      "specificity": "0,0,2,0",
+      "parts": [
+        {
+          "selector": ".box",
+          "type": "b",
+          "index": 0,
+          "length": 4
+        },
+        {
+          "selector": ":first-child",
+          "type": "b",
+          "index": 4,
+          "length": 12
+        }
+      ],
+      "specificity_10": 20
+    },
+    {
+      "selector": ".box:last-child",
+      "specificity": "0,0,2,0",
+      "parts": [
+        {
+          "selector": ".box",
+          "type": "b",
+          "index": 0,
+          "length": 4
+        },
+        {
+          "selector": ":last-child",
+          "type": "b",
+          "index": 4,
+          "length": 11
+        }
+      ],
+      "specificity_10": 20
     },
     {
       "selector": "0%",
@@ -273,28 +324,100 @@
       "childs": [
         {
           "type": "decl",
+          "prop": "margin",
+          "value": "10px",
+          "index": 8
+        },
+        {
+          "type": "decl",
+          "prop": "padding",
+          "value": "5px",
+          "index": 9
+        }
+      ],
+      "declarations": [
+        {
+          "type": "decl",
+          "prop": "margin",
+          "value": "10px",
+          "index": 8
+        },
+        {
+          "type": "decl",
+          "prop": "padding",
+          "value": "5px",
+          "index": 9
+        }
+      ],
+      "selector": ".box"
+    },
+    {
+      "type": "rule",
+      "childs": [
+        {
+          "type": "decl",
+          "prop": "margin",
+          "value": "0px 0",
+          "index": 10
+        }
+      ],
+      "declarations": [
+        {
+          "type": "decl",
+          "prop": "margin",
+          "value": "0px 0",
+          "index": 10
+        }
+      ],
+      "selector": ".box:first-child"
+    },
+    {
+      "type": "rule",
+      "childs": [
+        {
+          "type": "decl",
+          "prop": "margin-bottom",
+          "value": "0px",
+          "index": 11
+        }
+      ],
+      "declarations": [
+        {
+          "type": "decl",
+          "prop": "margin-bottom",
+          "value": "0px",
+          "index": 11
+        }
+      ],
+      "selector": ".box:last-child"
+    },
+    {
+      "type": "rule",
+      "childs": [
+        {
+          "type": "decl",
           "prop": "opacity",
           "value": "0",
-          "index": 8
+          "index": 12
         },
         {
           "type": "decl",
           "prop": "-webkit-transform",
           "value": "translateY(-20px) translate3d(0, 0, 0)",
-          "index": 9
+          "index": 13
         },
         {
           "type": "decl",
           "prop": "-ms-transform",
           "value": "translateY(-20px) translate3d(0, 0, 0)",
-          "index": 10
+          "index": 14
         },
         {
           "type": "decl",
           "prop": "transform",
           "important": true,
           "value": "translateY(-20px) translate3d(0, 0, 0)",
-          "index": 11
+          "index": 15
         }
       ],
       "declarations": [
@@ -302,26 +425,26 @@
           "type": "decl",
           "prop": "opacity",
           "value": "0",
-          "index": 8
+          "index": 12
         },
         {
           "type": "decl",
           "prop": "-webkit-transform",
           "value": "translateY(-20px) translate3d(0, 0, 0)",
-          "index": 9
+          "index": 13
         },
         {
           "type": "decl",
           "prop": "-ms-transform",
           "value": "translateY(-20px) translate3d(0, 0, 0)",
-          "index": 10
+          "index": 14
         },
         {
           "type": "decl",
           "prop": "transform",
           "important": true,
           "value": "translateY(-20px) translate3d(0, 0, 0)",
-          "index": 11
+          "index": 15
         }
       ],
       "selector": "0%"
@@ -333,25 +456,25 @@
           "type": "decl",
           "prop": "opacity",
           "value": "1",
-          "index": 12
+          "index": 16
         },
         {
           "type": "decl",
           "prop": "-webkit-transform",
           "value": "translateY(0) translate3d(0, 0, 0)",
-          "index": 13
+          "index": 17
         },
         {
           "type": "decl",
           "prop": "-ms-transform",
           "value": "translateY(0) translate3d(0, 0, 0)",
-          "index": 14
+          "index": 18
         },
         {
           "type": "decl",
           "prop": "transform",
           "value": "translateY(0) translate3d(0, 0, 0)",
-          "index": 15
+          "index": 19
         }
       ],
       "declarations": [
@@ -359,25 +482,25 @@
           "type": "decl",
           "prop": "opacity",
           "value": "1",
-          "index": 12
+          "index": 16
         },
         {
           "type": "decl",
           "prop": "-webkit-transform",
           "value": "translateY(0) translate3d(0, 0, 0)",
-          "index": 13
+          "index": 17
         },
         {
           "type": "decl",
           "prop": "-ms-transform",
           "value": "translateY(0) translate3d(0, 0, 0)",
-          "index": 14
+          "index": 18
         },
         {
           "type": "decl",
           "prop": "transform",
           "value": "translateY(0) translate3d(0, 0, 0)",
-          "index": 15
+          "index": 19
         }
       ],
       "selector": "100%"
@@ -436,52 +559,76 @@
       },
       {
         "type": "decl",
+        "prop": "margin",
+        "value": "10px",
+        "index": 8
+      },
+      {
+        "type": "decl",
+        "prop": "padding",
+        "value": "5px",
+        "index": 9
+      },
+      {
+        "type": "decl",
+        "prop": "margin",
+        "value": "0px 0",
+        "index": 10
+      },
+      {
+        "type": "decl",
+        "prop": "margin-bottom",
+        "value": "0px",
+        "index": 11
+      },
+      {
+        "type": "decl",
         "prop": "opacity",
         "value": "0",
-        "index": 8
+        "index": 12
       },
       {
         "type": "decl",
         "prop": "-webkit-transform",
         "value": "translateY(-20px) translate3d(0, 0, 0)",
-        "index": 9
+        "index": 13
       },
       {
         "type": "decl",
         "prop": "-ms-transform",
         "value": "translateY(-20px) translate3d(0, 0, 0)",
-        "index": 10
+        "index": 14
       },
       {
         "type": "decl",
         "prop": "transform",
         "important": true,
         "value": "translateY(-20px) translate3d(0, 0, 0)",
-        "index": 11
+        "index": 15
       },
       {
         "type": "decl",
         "prop": "opacity",
         "value": "1",
-        "index": 12
+        "index": 16
       },
       {
         "type": "decl",
         "prop": "-webkit-transform",
         "value": "translateY(0) translate3d(0, 0, 0)",
-        "index": 13
+        "index": 17
       },
       {
         "type": "decl",
         "prop": "-ms-transform",
         "value": "translateY(0) translate3d(0, 0, 0)",
-        "index": 14
+        "index": 18
       },
       {
         "type": "decl",
         "prop": "transform",
         "value": "translateY(0) translate3d(0, 0, 0)",
-        "index": 15
+        "index": 19
       }
     ],
     "byProperty": {
@@ -541,13 +688,13 @@
           "type": "decl",
           "prop": "opacity",
           "value": "0",
-          "index": 8
+          "index": 12
         },
         {
           "type": "decl",
           "prop": "opacity",
           "value": "1",
-          "index": 12
+          "index": 16
         }
       ],
       "borderBottom": [
@@ -558,18 +705,48 @@
           "index": 7
         }
       ],
+      "margin": [
+        {
+          "type": "decl",
+          "prop": "margin",
+          "value": "10px",
+          "index": 8
+        },
+        {
+          "type": "decl",
+          "prop": "margin",
+          "value": "0px 0",
+          "index": 10
+        }
+      ],
+      "padding": [
+        {
+          "type": "decl",
+          "prop": "padding",
+          "value": "5px",
+          "index": 9
+        }
+      ],
+      "marginBottom": [
+        {
+          "type": "decl",
+          "prop": "margin-bottom",
+          "value": "0px",
+          "index": 11
+        }
+      ],
       "webkitTransform": [
         {
           "type": "decl",
           "prop": "-webkit-transform",
           "value": "translateY(-20px) translate3d(0, 0, 0)",
-          "index": 9
+          "index": 13
         },
         {
           "type": "decl",
           "prop": "-webkit-transform",
           "value": "translateY(0) translate3d(0, 0, 0)",
-          "index": 13
+          "index": 17
         }
       ],
       "msTransform": [
@@ -577,13 +754,13 @@
           "type": "decl",
           "prop": "-ms-transform",
           "value": "translateY(-20px) translate3d(0, 0, 0)",
-          "index": 10
+          "index": 14
         },
         {
           "type": "decl",
           "prop": "-ms-transform",
           "value": "translateY(0) translate3d(0, 0, 0)",
-          "index": 14
+          "index": 18
         }
       ],
       "transform": [
@@ -592,13 +769,13 @@
           "prop": "transform",
           "important": true,
           "value": "translateY(-20px) translate3d(0, 0, 0)",
-          "index": 11
+          "index": 15
         },
         {
           "type": "decl",
           "prop": "transform",
           "value": "translateY(0) translate3d(0, 0, 0)",
-          "index": 15
+          "index": 19
         }
       ]
     },
@@ -653,13 +830,13 @@
           "type": "decl",
           "prop": "opacity",
           "value": "0",
-          "index": 8
+          "index": 12
         },
         {
           "type": "decl",
           "prop": "opacity",
           "value": "1",
-          "index": 12
+          "index": 16
         }
       ],
       "borderBottom": [
@@ -670,18 +847,48 @@
           "index": 7
         }
       ],
+      "margin": [
+        {
+          "type": "decl",
+          "prop": "margin",
+          "value": "10px",
+          "index": 8
+        },
+        {
+          "type": "decl",
+          "prop": "margin",
+          "value": "0px 0",
+          "index": 10
+        }
+      ],
+      "padding": [
+        {
+          "type": "decl",
+          "prop": "padding",
+          "value": "5px",
+          "index": 9
+        }
+      ],
+      "marginBottom": [
+        {
+          "type": "decl",
+          "prop": "margin-bottom",
+          "value": "0px",
+          "index": 11
+        }
+      ],
       "webkitTransform": [
         {
           "type": "decl",
           "prop": "-webkit-transform",
           "value": "translateY(-20px) translate3d(0, 0, 0)",
-          "index": 9
+          "index": 13
         },
         {
           "type": "decl",
           "prop": "-webkit-transform",
           "value": "translateY(0) translate3d(0, 0, 0)",
-          "index": 13
+          "index": 17
         }
       ],
       "msTransform": [
@@ -689,13 +896,13 @@
           "type": "decl",
           "prop": "-ms-transform",
           "value": "translateY(-20px) translate3d(0, 0, 0)",
-          "index": 10
+          "index": 14
         },
         {
           "type": "decl",
           "prop": "-ms-transform",
           "value": "translateY(0) translate3d(0, 0, 0)",
-          "index": 14
+          "index": 18
         }
       ],
       "transform": [
@@ -704,13 +911,13 @@
           "prop": "transform",
           "important": true,
           "value": "translateY(-20px) translate3d(0, 0, 0)",
-          "index": 11
+          "index": 15
         },
         {
           "type": "decl",
           "prop": "transform",
           "value": "translateY(0) translate3d(0, 0, 0)",
-          "index": 15
+          "index": 19
         }
       ]
     },
@@ -736,14 +943,18 @@
         }
       ]
     },
+    "propertyResetDeclarations": {
+      "margin": 1,
+      "marginBottom": 1
+    },
     "importantCount": 2,
     "vendorPrefixCount": 5,
     "displayNoneCount": 0,
-    "uniqueDeclarationsCount": 15
+    "uniqueDeclarationsCount": 19
   },
   "aggregates": {
-    "selectors": 8,
-    "declarations": 16,
+    "selectors": 11,
+    "declarations": 20,
     "properties": [
       "color",
       "backgroundColor",
@@ -751,6 +962,9 @@
       "content",
       "opacity",
       "borderBottom",
+      "margin",
+      "padding",
+      "marginBottom",
       "webkitTransform",
       "msTransform",
       "transform"
@@ -782,6 +996,18 @@
       "total": 1,
       "unique": 1
     },
+    "margin": {
+      "total": 2,
+      "unique": 2
+    },
+    "padding": {
+      "total": 1,
+      "unique": 1
+    },
+    "marginBottom": {
+      "total": 1,
+      "unique": 1
+    },
     "webkitTransform": {
       "total": 2,
       "unique": 2
@@ -795,11 +1021,11 @@
       "unique": 2
     },
     "idSelectors": 1,
-    "classSelectors": 5,
+    "classSelectors": 8,
     "repeatedSelectors": [
       ".red"
     ],
-    "pseudoClassSelectors": 1,
+    "pseudoClassSelectors": 3,
     "pseudoElementSelectors": 1
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -22,33 +22,33 @@ describe('css-statistics', function() {
   describe('base stats', function() {
 
     it('should calculate the correct file size', function() {
-      assert.equal(stats.size, 713);
+      assert.equal(stats.size, 827);
     });
 
     it('should calculate the correct gzipped file size', function() {
-      assert.equal(stats.gzipSize, 293);
+      assert.equal(stats.gzipSize, 336);
     });
   });
 
   describe('averages', function() {
 
     it('should correctly count specificity stats', function() {
-      assert.equal(stats.averages.specificity, 21.625);
+      assert.equal(stats.averages.specificity, 20.272727272727273);
     });
 
     it('should correctly count rule size stats', function() {
-      assert.equal(stats.averages.ruleSize, 2.2857142857142856);
+      assert.equal(stats.averages.ruleSize, 2);
     });
   });
 
   describe('aggregates', function() {
 
     it('should correctly count declarations', function() {
-      assert.equal(stats.aggregates.declarations, 16);
+      assert.equal(stats.aggregates.declarations, 20);
     });
 
     it('should correctly count selectors', function() {
-      assert.equal(stats.aggregates.selectors, 8);
+      assert.equal(stats.aggregates.selectors, 11);
     });
 
     it('should correctly count the number of id selectors', function() {
@@ -56,7 +56,7 @@ describe('css-statistics', function() {
     });
 
     it('should correctly count the number of class selectors', function() {
-      assert.equal(stats.aggregates.classSelectors, 5);
+      assert.equal(stats.aggregates.classSelectors, 8);
     });
 
     it('should correctly count the number of pseudo element selectors', function() {
@@ -64,7 +64,7 @@ describe('css-statistics', function() {
     });
 
     it('should correctly count the number of pseudo class selectors', function() {
-      assert.equal(stats.aggregates.pseudoClassSelectors, 1);
+      assert.equal(stats.aggregates.pseudoClassSelectors, 3);
     });
 
     it('should correctly aggregate the repeated selectors', function() {
@@ -83,8 +83,12 @@ describe('css-statistics', function() {
     });
 
     it('should correctly count the number of unique declarations', function() {
-      assert.equal(stats.declarations.uniqueDeclarationsCount, 15);
+      assert.equal(stats.declarations.uniqueDeclarationsCount, 19);
     })
+
+    it('should correctly count the number of declarations that reset properties', function() {
+      assert.deepEqual(stats.declarations.propertyResetDeclarations, {'margin': 1, 'marginBottom': 1});
+    });
   });
 
   describe('keyframes', function() {


### PR DESCRIPTION
Moved [this](https://github.com/cssstats/cssstats/pull/155) to css-statistics module. 

And enhanced it a bit. 

It now also includes `margin-right, margin-left, margin-top, margin-bottom` (same for padding) and all possible units (like `%, px, em, vmin`...)